### PR TITLE
Add hassfest

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: home-assistant/actions/hassfest@master

--- a/custom_components/zwift/manifest.json
+++ b/custom_components/zwift/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "zwift",
   "name": "Zwift Sensor",
-  "documentation": "",
+  "documentation": "https://github.com/snicker/zwift_hass/blob/master/README.md",
   "requirements": ["zwift-client==0.2.0"],
   "dependencies": [],
-  "codeowners": ["snicker"]
+  "codeowners": ["@snicker"]
 }


### PR DESCRIPTION
Add Hassfest validation as a github action & fix issues highlighted by the validation.
See https://developers.home-assistant.io/blog/2020/04/16/hassfest/ for more details.
This should hopefully pick up any issues against the next release of Home Assistant, so they can be fixed before it is a general release.