### PR TITLE
Ignore more profile attributes

### DIFF
--- a/custom_components/zwift/sensor.py
+++ b/custom_components/zwift/sensor.py
@@ -53,7 +53,20 @@ EVENT_ZWIFT_RIDE_ON = 'zwift_ride_on'
 
 ZWIFT_IGNORED_PROFILE_ATTRIBUTES = [
     'privateAttributes',
-    'publicAttributes'
+    'publicAttributes',
+    'connectedToStrava',
+    'connectedToTrainingPeaks',
+    'connectedToTodaysPlan',
+    'connectedToUnderArmour',
+    'connectedToWithings',
+    'connectedToFitbit',
+    'connectedToGarmin',
+    'connectedToRuntastic',
+    'mixpanelDistinctId',
+    'bigCommerceId',
+    'avantlinkId',
+    'userAgent',
+    'launchedGameClient'
 ]
 
 ZWIFT_WORLDS = {


### PR DESCRIPTION
Having looked through the profile details, I'd like to propose ignoring a number of additional attributes since they are either static and irrelevant (like the ad identifiers) or not really relevant (like the connectedToStrava properties, etc)

- connectedToX: I'd argue these are very static and not really interesting
- mixpanelDistinctId, bigCommerceId, avantlinkId - these seem to be ad-identifiers without any practical relevance
- userAgent and launchedGameClient are static and not the current dates, additionally launchedGameClient is a duplicate of createdOn