### PR TITLE
Round several sensor values to 0 or 1 digit, fixes #2

### DIFF
--- a/custom_components/zwift/sensor.py
+++ b/custom_components/zwift/sensor.py
@@ -226,19 +226,19 @@ class ZwiftPlayerData:
 
     @property
     def hr(self):
-        return self.data.get('heartrate',0.0)
+        return round(self.data.get('heartrate', 0.0), 0)
 
     @property
     def speed(self):
-        return self.data.get('speed',0.0)
+        return round(self.data.get('speed', 0.0), 0)
 
     @property
     def cadence(self):
-        return self.data.get('cadence',0.0)
+        return round(self.data.get('cadence', 0.0), 0)
 
     @property
     def power(self):
-        return self.data.get('power',0.0)
+        return round(self.data.get('power', 0.0), 0)
 
     @property
     def altitude(self):
@@ -246,11 +246,11 @@ class ZwiftPlayerData:
 
     @property
     def distance(self):
-        return self.data.get('distance',0.0)
+        return self.data.get('distance', 0.0)
 
     @property
     def gradient(self):
-        return self.data.get('gradient',0.0)
+        return round(self.data.get('gradient', 0.0), 1)
 
     @property
     def level(self):

--- a/custom_components/zwift/sensor.py
+++ b/custom_components/zwift/sensor.py
@@ -242,7 +242,7 @@ class ZwiftPlayerData:
 
     @property
     def altitude(self):
-        return self.data.get('altitude',0.0)
+        return round(self.data.get('altitude', 0.0), 1)
 
     @property
     def distance(self):


### PR DESCRIPTION
Refs #2, fixes excessive decimals for altitude sensors 

EDIT: I’ve also gone ahead and added rounding for some of the other sensors as values like the ones below seem unreasonable

![B766EDE2-B2D2-4523-BD4A-5C27D25C06D5](https://user-images.githubusercontent.com/26942220/103456512-629cac00-4cf7-11eb-86ca-65096c49dbac.jpeg)

