### PR TITLE
implement protobuf workaround 

### DIFF
--- a/custom_components/zwift/sensor.py
+++ b/custom_components/zwift/sensor.py
@@ -338,6 +338,8 @@ class ZwiftData:
         return False
 
     async def _connect(self):
+        import os
+        os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
         from zwift import Client as ZwiftClient
         client = ZwiftClient(self.username, self.password)
         if await self.check_zwift_auth(client):


### PR DESCRIPTION
force protobuf implementation to use pure python until upstream zwift-client library is recompiled for newer version of protobuf. fixes #37 